### PR TITLE
Only override standard User Agents (with Mozilla prefix)

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -387,8 +387,9 @@ static const void *InjectedKey = &InjectedKey;
 %hook NSMutableURLRequest
 
 - (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)field {
-    if ([field caseInsensitiveCompare:@"User-Agent"] == NSOrderedSame)
+    if ([value hasPrefix:@"Mozilla"] && [field caseInsensitiveCompare:@"User-Agent"] == NSOrderedSame) {
         value = IS_IPAD ? desktopUserAgent : mobileUserAgent;
+    }
     %orig(value, field);
 }
 


### PR DESCRIPTION
This replaces the TestFlight-specific user agent exception, since it weirdly causes system deadlocks on iOS 15

This solution would also apply to other apps with similar issues